### PR TITLE
Updated links of documentation

### DIFF
--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -12,12 +12,12 @@ AngelConfigurer configureServer(FileSystem fileSystem) {
   return (Angel app) async {
     // Load configuration from the `config/` directory.
     //
-    // See: https://github.com/angel-dart/configuration
+    // See: https://github.com/angel-dart/angel/tree/master/packages/configuration
     await app.configure(configuration(fileSystem));
 
     // Configure our application to render Jael templates from the `views/` directory.
     //
-    // See: https://github.com/angel-dart/jael
+    // See: https://github.com/angel-dart/angel/tree/master/packages/jael
     await app.configure(jael(fileSystem.directory('views')));
 
     // Apply another plug-ins, i.e. ones that *you* have written.

--- a/lib/src/routes/routes.dart
+++ b/lib/src/routes/routes.dart
@@ -9,8 +9,8 @@ import 'controllers/controllers.dart' as controllers;
 /// Put your app routes here!
 ///
 /// See the wiki for information about routing, requests, and responses:
-/// * https://github.com/angel-dart/angel/wiki/Basic-Routing
-/// * https://github.com/angel-dart/angel/wiki/Requests-&-Responses
+/// * https://docs.angel-dart.dev/guides/basic-routing-1
+/// * https://docs.angel-dart.dev/guides/requests-and-responses
 AngelConfigurer configureServer(FileSystem fileSystem) {
   return (Angel app) async {
     // Typically, you want to mount controllers first, after any global middleware.
@@ -27,7 +27,7 @@ AngelConfigurer configureServer(FileSystem fileSystem) {
     //
     // Read the following two sources for documentation:
     // * https://medium.com/the-angel-framework/serving-static-files-with-the-angel-framework-2ddc7a2b84ae
-    // * https://github.com/angel-dart/static
+    // * https://github.com/angel-dart/angel/tree/master/packages/static
     if (!app.environment.isProduction) {
       var vDir = VirtualDirectory(
         app,
@@ -43,7 +43,7 @@ AngelConfigurer configureServer(FileSystem fileSystem) {
     // Set our application up to handle different errors.
     //
     // Read the following for documentation:
-    // * https://github.com/angel-dart/angel/wiki/Error-Handling
+    // * https://docs.angel-dart.dev/guides/error-handling
 
     var oldErrorHandler = app.errorHandler;
     app.errorHandler = (e, req, res) async {

--- a/lib/src/services/services.dart
+++ b/lib/src/services/services.dart
@@ -11,5 +11,5 @@ import 'package:angel_framework/angel_framework.dart';
 /// and respond to both REST and WebSockets.
 ///
 /// Read more here:
-/// https://github.com/angel-dart/angel/wiki/Service-Basics
+/// https://docs.angel-dart.dev/guides/service-basics
 Future configureServer(Angel app) async {}

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -13,7 +13,7 @@ import 'package:test/test.dart';
 // would have to first bind a socket, and then account for network latency.
 //
 // See the documentation here:
-// https://github.com/angel-dart/test
+// https://github.com/angel-dart/angel/tree/master/packages/test
 //
 // If you are unfamiliar with Dart's advanced testing library, you can read up
 // here:


### PR DESCRIPTION
Updated URLs in:

In the file (lib/src/):
1. config/config.dart: URL the package (configuration and jael)
2. routes/routes.dart: URL the documentation (basic-routing, requests-and-responses and error-handling) and package static
3. services/services.dart: URL the documentation of services-basics

test/all_test.dart: URL the package of test